### PR TITLE
docs(readme): sync with v0.3.6 / v0.3.7 — add review-spec + three-gate workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ cp specs/_template.spec.md specs/my-feature.spec.md
 | Command                         | Purpose                                                   |
 | ------------------------------- | --------------------------------------------------------- |
 | `/ai-driver:init`               | Scaffold AI-driver files into the current project         |
-| `/ai-driver:run-spec <file>`    | Execute a spec end-to-end: plan, implement, test, PR      |
+| `/ai-driver:run-spec <file>`    | Execute a spec end-to-end: **Phase 0 spec review** → plan → implement → test → PR |
+| `/ai-driver:review-spec <file>` | Standalone three-layer spec review (mechanical + Claude + Codex); iterate on a draft before cutting a branch |
 | `/ai-driver:review-pr [number]` | Dual-blind PR review (Claude + Codex); reads all existing reviews/comments (incl. Copilot) |
 | `/ai-driver:merge-pr [number]`  | Merge PR, update CHANGELOG, tag, trigger release          |
 | `/ai-driver:doctor`             | Read-only health check — detects drift and misconfiguration |
@@ -74,6 +75,7 @@ AI-driver commands do **not** hard-code a model or effort level — you stay in 
 | Command                 | Suggested session setting                                       |
 | ----------------------- | --------------------------------------------------------------- |
 | `/ai-driver:run-spec`   | Opus + `xhigh` effort (multi-step planning, TDD, orchestration) |
+| `/ai-driver:review-spec`| Opus + `xhigh` effort (adversarial reading of the spec) |
 | `/ai-driver:review-pr`  | Opus + `xhigh` effort (adversarial deep-read of the diff)       |
 | `/ai-driver:merge-pr`   | Sonnet or session default (deterministic: rewrite CHANGELOG, merge, tag) |
 | `/ai-driver:doctor`     | Haiku or session default (pure read-only — file checks + diff) |
@@ -120,14 +122,23 @@ Commands and language rules live inside the installed plugin, not in your projec
 ## Workflow
 
 ```txt
-Human writes spec → /ai-driver:run-spec → AI plan+code+test → PR
-                                                              ↓
-              /ai-driver:review-pr → Claude+Codex review → merge
-                                                              ↓
-                           GitHub Actions → tag + release
-                                                              ↓
+Human writes spec → /ai-driver:run-spec
+                         ↓
+            Phase 0: spec review  (Layer 0 grep + Claude + Codex)   ← gate 1/3
+                         ↓
+            Phase 1: plan review  (Codex adversarial on plan)       ← gate 2/3
+                         ↓
+                  AI code + test → PR
+                         ↓
+                  /ai-driver:review-pr                               ← gate 3/3
+                  (Claude + Codex + existing reviewer consensus)
+                         ↓
+                  /ai-driver:merge-pr → GitHub Actions → tag + release
+                         ↓
        Human tests → issue → /ai-driver:fix-issues → PR → ...
 ```
+
+The three-gate pipeline (v0.3.6+) catches defects at the cheapest stage: spec before plan, plan before code, code before merge. Each gate runs Claude (in-session) + Codex (external) with dual-consensus severity upgrades. Standalone `/ai-driver:review-spec` lets you pre-flight a draft spec without cutting a branch.
 
 ## Standards
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ AI-driver commands do **not** hard-code a model or effort level — you stay in 
 | Command                 | Suggested session setting                                       |
 | ----------------------- | --------------------------------------------------------------- |
 | `/ai-driver:run-spec`   | Opus + `xhigh` effort (multi-step planning, TDD, orchestration) |
-| `/ai-driver:review-spec`| Opus + `xhigh` effort (adversarial reading of the spec) |
+| `/ai-driver:review-spec` | Opus + `xhigh` effort (adversarial reading of the spec) |
 | `/ai-driver:review-pr`  | Opus + `xhigh` effort (adversarial deep-read of the diff)       |
 | `/ai-driver:merge-pr`   | Sonnet or session default (deterministic: rewrite CHANGELOG, merge, tag) |
 | `/ai-driver:doctor`     | Haiku or session default (pure read-only — file checks + diff) |
@@ -124,21 +124,26 @@ Commands and language rules live inside the installed plugin, not in your projec
 ```txt
 Human writes spec → /ai-driver:run-spec
                          ↓
-            Phase 0: spec review  (Layer 0 grep + Claude + Codex)   ← gate 1/3
+    Phase 0: spec review  (Layer 0 grep + Claude + Codex, unconditional)   ← gate 1/3
                          ↓
-            Phase 1: plan review  (Codex adversarial on plan)       ← gate 2/3
+    Phase 1: plan review  (Codex adversarial, ONLY when Review Level ≥ B)  ← gate 2/3 (optional)
                          ↓
                   AI code + test → PR
                          ↓
-                  /ai-driver:review-pr                               ← gate 3/3
-                  (Claude + Codex + existing reviewer consensus)
+                  /ai-driver:review-pr                                     ← gate 3/3
+                  (Claude + Codex + existing reviewer, triple-consensus)
                          ↓
                   /ai-driver:merge-pr → GitHub Actions → tag + release
                          ↓
        Human tests → issue → /ai-driver:fix-issues → PR → ...
 ```
 
-The three-gate pipeline (v0.3.6+) catches defects at the cheapest stage: spec before plan, plan before code, code before merge. Each gate runs Claude (in-session) + Codex (external) with dual-consensus severity upgrades. Standalone `/ai-driver:review-spec` lets you pre-flight a draft spec without cutting a branch.
+The three-gate pipeline (v0.3.6+) catches defects at the cheapest stage: spec before plan, plan before code, code before merge. **The three gates are not identical:**
+- **Gate 1** (spec review) runs Layer 0 mechanical grep + Layer 1 Claude in-session + Layer 2 Codex external, with dual-consensus severity upgrade when both LLM layers agree. Unconditional — runs regardless of the spec's `Review Level`.
+- **Gate 2** (plan review inside `run-spec`) is an **optional** Codex-only adversarial pass, executed only when the spec's `Review Level` is `B` or `C`. No Claude pass, no dual-consensus semantics.
+- **Gate 3** (PR review) combines Claude Pass 1 + Codex Pass 2 + ingestion of existing reviewer comments (Copilot / humans / bots) for triple-consensus severity upgrades.
+
+Standalone `/ai-driver:review-spec` lets you pre-flight a draft spec without cutting a branch — same Layer 0 + Layer 1 + Layer 2 as Gate 1.
 
 ## Standards
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,16 +54,17 @@ cp specs/_template.spec.md specs/my-feature.spec.md
 
 ## 命令一览
 
-| 命令                          | 作用                                     |
-| ----------------------------- | ---------------------------------------- |
-| `/ai-driver:init`             | 把 AI-driver 文件铺到当前项目            |
-| `/ai-driver:run-spec <文件>`  | 端到端执行 spec：规划、实现、测试、提 PR |
-| `/ai-driver:review-pr [编号]` | Claude + Codex 双盲 PR 审查；读取全部已有 review/评论（含 Copilot） |
-| `/ai-driver:merge-pr [编号]`  | 合并 PR、更新 CHANGELOG、打 tag、触发发版 |
-| `/ai-driver:doctor`           | 只读健康检查 —— 探测漂移和误配置        |
-| `/ai-driver:fix-issues`       | 批量修复带 `ai-fix` 标签的 GitHub issue；读取完整 issue 线程含 bot 诊断 |
-| `/ai-driver:run-tests`        | 自动识别并运行项目测试                   |
-| `/ai-driver:deploy <环境>`    | 按 `deploy/<project>.deploy.md` 执行部署 |
+| 命令                            | 作用                                     |
+| ------------------------------- | ---------------------------------------- |
+| `/ai-driver:init`               | 把 AI-driver 文件铺到当前项目            |
+| `/ai-driver:run-spec <文件>`    | 端到端执行 spec：**Phase 0 spec 审查** → 规划 → 实现 → 测试 → 提 PR |
+| `/ai-driver:review-spec <文件>` | 独立三层 spec 审查（机械 grep + Claude + Codex）；在切分支前迭代草稿 spec |
+| `/ai-driver:review-pr [编号]`   | Claude + Codex 双盲 PR 审查；读取全部已有 review/评论（含 Copilot） |
+| `/ai-driver:merge-pr [编号]`    | 合并 PR、更新 CHANGELOG、打 tag、触发发版 |
+| `/ai-driver:doctor`             | 只读健康检查 —— 探测漂移和误配置        |
+| `/ai-driver:fix-issues`         | 批量修复带 `ai-fix` 标签的 GitHub issue；读取完整 issue 线程含 bot 诊断 |
+| `/ai-driver:run-tests`          | 自动识别并运行项目测试                   |
+| `/ai-driver:deploy <环境>`      | 按 `deploy/<project>.deploy.md` 执行部署 |
 
 完整命令定义见 [`plugins/ai-driver/commands/`](plugins/ai-driver/commands)。
 
@@ -71,16 +72,17 @@ cp specs/_template.spec.md specs/my-feature.spec.md
 
 AI-driver 命令**不**在 frontmatter 里写死 `model` / `effort`，你自己控制。调用前按需切换：
 
-| 命令                    | 建议会话设置                                       |
-| ----------------------- | -------------------------------------------------- |
-| `/ai-driver:run-spec`   | Opus + `xhigh` effort（多步规划 + TDD + 任务编排） |
-| `/ai-driver:review-pr`  | Opus + `xhigh` effort（对抗性深读 diff）           |
-| `/ai-driver:merge-pr`   | Sonnet 或会话默认（确定性流程：改 CHANGELOG、合并、打 tag） |
-| `/ai-driver:doctor`     | Haiku 或会话默认（纯只读：文件对比 + diff）         |
-| `/ai-driver:fix-issues` | Opus + `xhigh` effort（根因分析）                  |
-| `/ai-driver:run-tests`  | Haiku 或会话默认（跑命令、解析输出）               |
-| `/ai-driver:deploy`     | Sonnet 或会话默认（按部署文档走步骤）              |
-| `/ai-driver:init`       | 会话默认（文件复制 + jq 合并）                     |
+| 命令                     | 建议会话设置                                       |
+| ------------------------ | -------------------------------------------------- |
+| `/ai-driver:run-spec`    | Opus + `xhigh` effort（多步规划 + TDD + 任务编排） |
+| `/ai-driver:review-spec` | Opus + `xhigh` effort（对抗性读 spec）             |
+| `/ai-driver:review-pr`   | Opus + `xhigh` effort（对抗性深读 diff）           |
+| `/ai-driver:merge-pr`    | Sonnet 或会话默认（确定性流程：改 CHANGELOG、合并、打 tag） |
+| `/ai-driver:doctor`      | Haiku 或会话默认（纯只读：文件对比 + diff）         |
+| `/ai-driver:fix-issues`  | Opus + `xhigh` effort（根因分析）                  |
+| `/ai-driver:run-tests`   | Haiku 或会话默认（跑命令、解析输出）               |
+| `/ai-driver:deploy`      | Sonnet 或会话默认（按部署文档走步骤）              |
+| `/ai-driver:init`        | 会话默认（文件复制 + jq 合并）                     |
 
 在 Claude Code 会话里临时切换：
 
@@ -120,14 +122,23 @@ deploy/             — 可选的部署文档
 ## 工作流
 
 ```txt
-人写 spec → /ai-driver:run-spec → AI 计划 + 编码 + 测试 → PR
-                                                        ↓
-          /ai-driver:review-pr → Claude+Codex 审查 → merge
-                                                        ↓
-                     GitHub Actions → tag + release
-                                                        ↓
+人写 spec → /ai-driver:run-spec
+                  ↓
+      Phase 0: spec 审查 (Layer 0 grep + Claude + Codex)   ← 第 1/3 道门
+                  ↓
+      Phase 1: plan 审查 (Codex 对抗读 plan)              ← 第 2/3 道门
+                  ↓
+             AI 编码 + 测试 → PR
+                  ↓
+             /ai-driver:review-pr                          ← 第 3/3 道门
+             (Claude + Codex + 已有 reviewer 三方共识)
+                  ↓
+             /ai-driver:merge-pr → GitHub Actions → tag + release
+                  ↓
         人工测试 → issue → /ai-driver:fix-issues → PR → ...
 ```
+
+三门流水线（v0.3.6+）在最便宜的阶段夹断缺陷：spec 在 plan 之前、plan 在 code 之前、code 在 merge 之前。每道门都跑 Claude（会话内）+ Codex（外部），双方共识则升一级严重度。独立的 `/ai-driver:review-spec` 让你在切分支之前先对草稿 spec 做预检。
 
 ## 规范遵从
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -124,21 +124,26 @@ deploy/             — 可选的部署文档
 ```txt
 人写 spec → /ai-driver:run-spec
                   ↓
-      Phase 0: spec 审查 (Layer 0 grep + Claude + Codex)   ← 第 1/3 道门
+   Phase 0: spec 审查（Layer 0 grep + Claude + Codex，无条件）    ← 第 1/3 道门
                   ↓
-      Phase 1: plan 审查 (Codex 对抗读 plan)              ← 第 2/3 道门
+   Phase 1: plan 审查（Codex 对抗，仅当 Review Level ≥ B 才跑）    ← 第 2/3 道门（可选）
                   ↓
              AI 编码 + 测试 → PR
                   ↓
-             /ai-driver:review-pr                          ← 第 3/3 道门
-             (Claude + Codex + 已有 reviewer 三方共识)
+             /ai-driver:review-pr                                  ← 第 3/3 道门
+             （Claude + Codex + 已有 reviewer，三方共识）
                   ↓
              /ai-driver:merge-pr → GitHub Actions → tag + release
                   ↓
         人工测试 → issue → /ai-driver:fix-issues → PR → ...
 ```
 
-三门流水线（v0.3.6+）在最便宜的阶段夹断缺陷：spec 在 plan 之前、plan 在 code 之前、code 在 merge 之前。每道门都跑 Claude（会话内）+ Codex（外部），双方共识则升一级严重度。独立的 `/ai-driver:review-spec` 让你在切分支之前先对草稿 spec 做预检。
+三门流水线（v0.3.6+）在最便宜的阶段夹断缺陷：spec 在 plan 之前、plan 在 code 之前、code 在 merge 之前。**三道门的审查方式并不相同：**
+- **第 1 道门**（spec 审查）：Layer 0 机械 grep + Layer 1 Claude 会话内 + Layer 2 Codex 外部；两个 LLM 层共识则升一级严重度。**无条件**执行，不看 `Review Level`。
+- **第 2 道门**（run-spec 里的 plan 审查）：**可选** Codex-only 对抗，只在 spec 的 `Review Level` 为 `B` 或 `C` 时跑。无 Claude 层，也无双共识语义。
+- **第 3 道门**（PR 审查）：Claude Pass 1 + Codex Pass 2 + 摄取已有 reviewer 评论（Copilot/人工/bot），三方共识则升一级严重度。
+
+独立的 `/ai-driver:review-spec` 让你在切分支之前先对草稿 spec 做预检 — 跟第 1 道门同一套 Layer 0 + Layer 1 + Layer 2。
 
 ## 规范遵从
 


### PR DESCRIPTION
## Summary

README.md and README.zh-CN.md were missing `/ai-driver:review-spec` (shipped in v0.3.6) from both the command table and the per-command model table. The Workflow diagram still showed the pre-v0.3.6 two-step flow and did not reflect the three-gate pipeline (spec review → plan review → PR review).

Pure documentation sync — no functional change.

### Changes

- **Command table**: added `/ai-driver:review-spec <file>` row in both locales.
- **Model-per-command table**: added `/ai-driver:review-spec` row with suggested Opus + `xhigh`.
- **`run-spec` description**: now names "Phase 0 spec review" as the first step of its pipeline.
- **Workflow diagram**: redrawn to show all three gates explicitly + a short paragraph explaining the "catch defects at the cheapest stage" principle.

### Why separate PR

Caught on human review after v0.3.7 shipped. These tables are the first place a user lands; leaving `review-spec` out means new users miss the upstream gate entirely.

### Release mode

I have **not** touched `CHANGELOG.md` or `marketplace.json` — this PR deliberately has no `[Unreleased]` entries because it adds no feature and fixes no user-visible bug. Recommended merge mode: `/ai-driver:merge-pr 10 --no-release` (merge-only, no tag, no release). If you prefer a docs patch release, pass `--version 0.3.8` and I'll add the `[Unreleased]` bullets on the release commit.

## Test plan

- [x] `grep review-spec README.md` → 3 matches (command table + model table + workflow blurb)
- [x] `grep review-spec README.zh-CN.md` → 3 matches (same)
- [x] Diff reviewed; no functional claims changed, all accurate as of v0.3.7
- [ ] CI: `Template Sync` + new `Injection Lint` both green (README files are not in PAIRS, shouldn't affect template-sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)