### PR TITLE
docs(constitution): add R-009 Review Runs In A Sandbox Executor (approved in PR #11)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Language-agnostic AI-driven development framework. Humans write specs, AI does the rest.",
-    "version": "0.3.8"
+    "version": "0.3.9"
   },
   "plugins": [
     {
       "name": "ai-driver",
       "source": "./plugins/ai-driver",
       "description": "Claude Code plugin for the AI-driver framework",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "author": {
         "name": "HuMoran"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-04-20
+
 ### Changed
 
 - `constitution.md` adds **R-009: Review Runs In A Sandbox Executor** (proposed in PR #11, approved by @HuMoran in PR #11 comment thread on 2026-04-20, landed via PR #12 post-v0.3.8). Codifies the v0.3.8 behavioural contract at constitutional authority: every AI review MUST run inside a sandboxed executor (Claude subagent for in-session, `codex exec` for external), main-session inline review is prohibited, untrusted external data is staged to files and handed to the subagent by path. Template pair (`plugins/ai-driver/templates/constitution.md`) mirrored so user projects pick up the rule on `claude plugin update`. No code change — v0.3.8 command docs already enforce R-009.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `constitution.md` adds **R-009: Review Runs In A Sandbox Executor** (proposed in PR #11, approved by @HuMoran in PR #11 comment thread on 2026-04-20, landed via PR #12 post-v0.3.8). Codifies the v0.3.8 behavioural contract at constitutional authority: every AI review MUST run inside a sandboxed executor (Claude subagent for in-session, `codex exec` for external), main-session inline review is prohibited, untrusted external data is staged to files and handed to the subagent by path. Template pair (`plugins/ai-driver/templates/constitution.md`) mirrored so user projects pick up the rule on `claude plugin update`. No code change — v0.3.8 command docs already enforce R-009.
+
 ## [0.3.8] - 2026-04-20
 
 ### Changed (BREAKING — architecture of all three review gates)

--- a/constitution.md
+++ b/constitution.md
@@ -80,6 +80,21 @@ implementation. Input gating is strictly cheaper than downstream correction.
 Enforcement: `/ai-driver:run-spec` exits 2 on any Critical finding. High findings
 require explicit `--accept-high` flag with rationale logged.
 
+### R-009: Review Runs In A Sandbox Executor (from P1, P4)
+Every AI review in this framework MUST run inside a sandboxed executor — a Claude Code
+subagent for the in-session Claude pass, `codex exec` for the external pass.
+Main-session inline review is prohibited. When a reviewer needs untrusted external
+data (PR bodies, issue threads, reviewer comments), the main session stages it to
+files via shell redirects; it never interpolates the raw content into its own prompt.
+Rationale: isolates untrusted-data contamination at the tool layer (defense-in-depth
+over the data-fence prose) and separates the implementer role from the reviewer role
+so implementation bias does not mask defects.
+Enforcement: subagent `allowed-tools` is exactly `Read, Grep, Glob` — no Write, no
+network, no nested `Agent`/`Task` spawn. Codex invocations use Claude Code's
+`Bash(run_in_background=true)`; `nohup codex … &` is forbidden. Return-channel
+sanitization (length caps + `|` / `` ` `` escape + fixed-literal `parse-error`
+message) prevents a compromised subagent from smuggling attacker bytes back.
+
 ## Standards
 
 - Changelog: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)

--- a/plugins/ai-driver/templates/constitution.md
+++ b/plugins/ai-driver/templates/constitution.md
@@ -80,6 +80,21 @@ implementation. Input gating is strictly cheaper than downstream correction.
 Enforcement: `/ai-driver:run-spec` exits 2 on any Critical finding. High findings
 require explicit `--accept-high` flag with rationale logged.
 
+### R-009: Review Runs In A Sandbox Executor (from P1, P4)
+Every AI review in this framework MUST run inside a sandboxed executor — a Claude Code
+subagent for the in-session Claude pass, `codex exec` for the external pass.
+Main-session inline review is prohibited. When a reviewer needs untrusted external
+data (PR bodies, issue threads, reviewer comments), the main session stages it to
+files via shell redirects; it never interpolates the raw content into its own prompt.
+Rationale: isolates untrusted-data contamination at the tool layer (defense-in-depth
+over the data-fence prose) and separates the implementer role from the reviewer role
+so implementation bias does not mask defects.
+Enforcement: subagent `allowed-tools` is exactly `Read, Grep, Glob` — no Write, no
+network, no nested `Agent`/`Task` spawn. Codex invocations use Claude Code's
+`Bash(run_in_background=true)`; `nohup codex … &` is forbidden. Return-channel
+sanitization (length caps + `|` / `` ` `` escape + fixed-literal `parse-error`
+message) prevents a compromised subagent from smuggling attacker bytes back.
+
 ## Standards
 
 - Changelog: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)


### PR DESCRIPTION
## Summary

Lands the constitution amendment approved by @HuMoran on PR #11 but missed from the v0.3.8 release commit chain because I didn't re-check the PR comment thread before running `/ai-driver:merge-pr`.

### Approval evidence

| When | Author | Body |
|---|---|---|
| 2026-04-20T11:12:13Z | @HuMoran (repo owner) | `approve as-is` |
| 2026-04-20T11:28:27Z | @HuMoran | `approve as-is` (re-confirmation) |

Both on PR #11. That meets `constitution.md` §Governance requirement for \"explicit human approval\".

### What landed

- `R-009: Review Runs In A Sandbox Executor` added to both `constitution.md` and `plugins/ai-driver/templates/constitution.md`.
- Text matches the proposal in PR #11's body verbatim, with an added **Enforcement** paragraph naming the specific tool-layer rules (`allowed-tools: Read, Grep, Glob`, `Bash(run_in_background=true)`, `nohup codex` forbidden, return-channel sanitization).

### Why a separate PR

Matches the v0.3.6 R-008 pattern: constitution amendments land as their own auditable commit, not mixed into the feature commit. The v0.3.8 feature code already enforces R-009 behaviorally (command docs were updated, ACs enforce it mechanically in specs); this PR elevates the rule to constitutional authority.

### v0.3.9 follow-ups (backlog — captured here so they don't get lost)

1. **`/ai-driver:review-pr` must ingest existing issue-comments before composing its verdict.** Today it iterates them in the `Existing reviewer findings` table but a hand-composed review body can still claim \"governance approval pending\" when an `approve as-is` is already posted. Fix: extract any R-00N proposal in the current PR body, grep issue-comments for matching approval/rejection, include the result in the verdict programmatically.
2. **`/ai-driver:merge-pr` must detect R-00N proposals in the PR body and block the merge** unless either (a) a matching approval comment from a repo owner/admin exists, or (b) `--accept-open-amendment` is passed with a note. This fixes the exact bug that caused this PR to be needed.

## Test plan

- [x] `grep -Fq 'R-009: Review Runs In A Sandbox Executor' constitution.md`
- [x] `diff constitution.md plugins/ai-driver/templates/constitution.md` is empty (template-sync will re-verify)
- [ ] CI: `Template Sync`, `Injection Lint`, `CI detect-and-test` all green
- [ ] After merge, tag / release is **not** required (this is docs-only, no behavioral change since the feature already shipped in v0.3.8). Recommended merge: `/ai-driver:merge-pr <N> --no-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)