### PR TITLE
fix(commands): drop hardcoded --model gpt-5.4 from codex calls

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Language-agnostic AI-driven development framework. Humans write specs, AI does the rest.",
-    "version": "0.4.5"
+    "version": "0.4.6"
   },
   "plugins": [
     {
       "name": "ai-driver",
       "source": "./plugins/ai-driver",
       "description": "Claude Code plugin for the AI-driver framework",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "author": {
         "name": "HuMoran"
       },

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,5 +1,0 @@
-# Codex project-level configuration
-# See: https://developers.openai.com/codex/config-advanced
-
-model = "gpt-5.4"
-model_reasoning_effort = "high"

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -19,7 +19,6 @@ jobs:
             ".github/workflows/auto-release.yml:plugins/ai-driver/templates/.github/workflows/auto-release.yml"
             ".github/workflows/ci.yml:plugins/ai-driver/templates/.github/workflows/ci.yml"
             ".github/workflows/template-sync.yml:plugins/ai-driver/templates/.github/workflows/template-sync.yml"
-            ".codex/config.toml:plugins/ai-driver/templates/.codex/config.toml"
             "constitution.md:plugins/ai-driver/templates/constitution.md"
             "CLAUDE.md:plugins/ai-driver/templates/CLAUDE.md"
             "specs/_template.spec.md:plugins/ai-driver/templates/specs/_template.spec.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Drop hardcoded `--model gpt-5.4` from all `codex exec` invocations.** `plugins/ai-driver/commands/run-spec.md` (Phase 0 Layer 2 spec review, Plan review Pass 2) and `plugins/ai-driver/commands/review-pr.md` (Pass 2 adversarial diff review) all hardcoded `--model gpt-5.4`, blocking automatic model upgrades when the user's `codex` CLI evolved. The flag is removed; codex CLI now picks its own default model (governed by `~/.codex/config.toml` or codex's built-in default), so the framework rides codex upgrades without per-release maintenance. Surrounding `--config model_reasoning_effort="high"` and `-s read-only` are preserved (P5 minimal change). Users who want to pin a model can still do so via `~/.codex/config.toml` or by injecting `-c model="..."` at the user level. Fixes #19.
+
 ## [0.4.5] - 2026-04-23
 
 Process-correction release. Fixes the zh-CN spec template so `/ai-driver:run-spec` Phase 0 Layer 0 accepts it again, and tightens Phase 0 Layer 1 / Layer 2 review contracts so findings that don't name a Goal-failure mode emit as observations instead of blocking the Verdict. Motivated by a live case where the template fix itself hit 6 review rounds because adversarial reviewers self-recursed on the same locations with ever-finer portability / precision objections — none of which would have caused the stated Goal to fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-04-29
+
 ### Changed
 
 - **Stop pinning Codex to `gpt-5.4` at every layer.** Issue #19 reported that `codex exec` invocations were hardcoded to `gpt-5.4` and would not follow upstream model upgrades. PR #20 removes the pin from two layers, so `codex exec` falls through to its own model resolution (which today picks codex CLI's default — typically the latest stable):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **Drop hardcoded `--model gpt-5.4` from all `codex exec` invocations.** `plugins/ai-driver/commands/run-spec.md` (Phase 0 Layer 2 spec review, Plan review Pass 2) and `plugins/ai-driver/commands/review-pr.md` (Pass 2 adversarial diff review) all hardcoded `--model gpt-5.4`, blocking automatic model upgrades when the user's `codex` CLI evolved. The flag is removed; codex CLI now picks its own default model (governed by `~/.codex/config.toml` or codex's built-in default), so the framework rides codex upgrades without per-release maintenance. Surrounding `--config model_reasoning_effort="high"` and `-s read-only` are preserved (P5 minimal change). Users who want to pin a model can still do so via `~/.codex/config.toml` or by injecting `-c model="..."` at the user level. Fixes #19.
+- **Stop pinning Codex to `gpt-5.4` at every layer.** Issue #19 reported that `codex exec` invocations were hardcoded to `gpt-5.4` and would not follow upstream model upgrades. PR #20 removes the pin from two layers, so `codex exec` falls through to its own model resolution (which today picks codex CLI's default — typically the latest stable):
+  1. `plugins/ai-driver/commands/run-spec.md` (Phase 0 Layer 2 spec review, Plan review Pass 2) and `plugins/ai-driver/commands/review-pr.md` (Pass 2 adversarial diff review) — drops `--model gpt-5.4` from all three `codex exec` invocations. Surrounding `--config model_reasoning_effort="high"` and `-s read-only` are preserved.
+  2. `/.codex/config.toml` and `/plugins/ai-driver/templates/.codex/config.toml` — **deleted in full**. They contained only `model = "gpt-5.4"` (now harmful) and `model_reasoning_effort = "high"` (now redundant — every `codex exec` call passes `-c model_reasoning_effort="high"` directly). The `template-sync.yml` PAIRS entry for `.codex/config.toml` is removed accordingly. Without this layer, downstream users who initialize a project from this template and lack a `model = "..."` line in `~/.codex/config.toml` would have stayed pinned to `gpt-5.4` even after the commands/ change. Existing reviewer (`copilot-pull-request-reviewer[bot]`) and Pass 1 (Claude) of `/ai-driver:review-pr` flagged this as a Goal-traceability gap.
+
+  Users who want to pin a specific model can still do so via `~/.codex/config.toml` or by injecting `-c model="..."` at the user level — both layers above are framework-side defaults, not user-side controls. Fixes #19.
 
 ## [0.4.5] - 2026-04-23
 

--- a/logs/fix-issue-19/plan.md
+++ b/logs/fix-issue-19/plan.md
@@ -1,0 +1,33 @@
+# Plan — fix-issue-19
+
+## Architecture
+
+无架构变更。三处文件内文本删除，相同模式：
+
+```
+Before: codex exec --model gpt-5.4 --config model_reasoning_effort="high" -s read-only ...
+After:  codex exec --config model_reasoning_effort="high" -s read-only ...
+```
+
+## Reuse analysis
+
+- 现有 `codex exec` 调用结构、prompt 注入、stdin fence、`-s read-only` 沙盒、超时机制全部保留。
+- 不引入新文件、新变量、新 helper。
+
+## Risk analysis
+
+| 风险 | 影响 | 缓解 |
+|------|------|------|
+| codex CLI 默认模型与 gpt-5.4 行为差异 | 审查输出可能略有不同 | 这是 issue 的预期目标——跟进新模型；prompt 通用不绑定具体模型 |
+| 用户 `~/.codex/config.toml` 缺失 `model` 字段 | 由 codex 内置默认接管 | codex CLI 自身保证默认值始终指向最新可用 |
+| 模板镜像漂移 | template-sync CI 失败 | 已确认 PAIRS 不含 `commands/*`，无需同步 |
+
+## Test strategy
+
+- AC1/AC4：grep 字面量缺失校验
+- AC2：调用次数不变，证明只去 flag、未误删行
+- AC3：周边参数保留，证明最小变更
+
+## TDD note
+
+本任务是单点删除，"测试先行"映射为：先写 AC（grep 校验），运行 → RED（当前 grep 命中 3 次），再删除 → GREEN（grep 不命中）。AC 已在 spec 中固化，等同先写测试。

--- a/logs/fix-issue-19/plan.md
+++ b/logs/fix-issue-19/plan.md
@@ -19,8 +19,10 @@ After:  codex exec --config model_reasoning_effort="high" -s read-only ...
 | 风险 | 影响 | 缓解 |
 |------|------|------|
 | codex CLI 默认模型与 gpt-5.4 行为差异 | 审查输出可能略有不同 | 这是 issue 的预期目标——跟进新模型；prompt 通用不绑定具体模型 |
-| 用户 `~/.codex/config.toml` 缺失 `model` 字段 | 由 codex 内置默认接管 | codex CLI 自身保证默认值始终指向最新可用 |
-| 模板镜像漂移 | template-sync CI 失败 | 已确认 PAIRS 不含 `commands/*`，无需同步 |
+| 项目级 `.codex/config.toml` 仍 pin `model = "gpt-5.4"`（首版漏掉的层） | 对于无 `~/.codex/config.toml model=` 行的新用户，可能仍被 pin 到 gpt-5.4 → Goal 失败 | 在跟进提交中整文件删除 `.codex/config.toml`（双侧），同时摘除 `template-sync.yml` PAIRS 中该 pair |
+| 模板镜像漂移（commands） | template-sync CI 失败 | 已确认 PAIRS 不含 `commands/*`，无需同步 |
+| 模板镜像漂移（template-sync.yml 自身 + .codex 删除） | template-sync CI 失败 | 双侧 `template-sync.yml` 同步更新；删除两侧 `.codex/config.toml` 后 PAIRS 中该条目同步摘除（AC6/AC7） |
+| 删除 `model_reasoning_effort` 配置项导致 codex 失去推理等级 | 审查质量下降 | 三处 `codex exec` 调用都已用 `-c model_reasoning_effort="high"` CLI flag 显式传入；项目级配置中该项是冗余的，删除无行为变化 |
 
 ## Test strategy
 

--- a/logs/fix-issue-19/tasks.md
+++ b/logs/fix-issue-19/tasks.md
@@ -24,13 +24,32 @@
 ## T5: 验收 — 运行 AC1..AC4
 
 - AC1: `! grep -rn -- '--model gpt-5\.4' plugins/ai-driver/commands/`
-- AC2: `codex exec` 出现 3 次
+- AC2: `codex exec` 出现 4 次（3 沙盒调用 + run-spec.md:380 prose 示例）
 - AC3: `model_reasoning_effort` 保留 3 次
 - AC4: `gpt-5.4` 字面量在 commands/ 下不再出现
-- Maps to: 全部 AC
+- Maps to: AC1..AC4
 
 ## T6: 提交 + PR
 
 - `git add specs/fix-issue-19.spec.md plugins/ai-driver/commands/run-spec.md plugins/ai-driver/commands/review-pr.md logs/fix-issue-19/`
 - Commit: `fix(commands): drop hardcoded --model gpt-5.4 from codex calls (#19)`
 - Push + `gh pr create`
+
+## T7: 跟进 PR review — 删除 .codex/config.toml（双侧）+ 摘除 PAIRS
+
+PR review 三源（Claude Pass 1 + Codex Pass 2 + Copilot ×4）共识：项目级 `.codex/config.toml` 仍 pin `model = "gpt-5.4"`，对从模板初始化的新用户可能违背 issue #19 Goal。扩展修复范围。
+
+- `git rm .codex/config.toml plugins/ai-driver/templates/.codex/config.toml`
+- 摘除 `.github/workflows/template-sync.yml` 与其镜像中 `.codex/config.toml` 的 PAIR 行
+- Maps to: AC5, AC6, AC7
+
+## T8: 验收 round 2 — 运行 AC1..AC7
+
+- 全部 AC 必须 PASS（AC5..AC7 是新加的）
+- Maps to: 全部 AC
+
+## T9: 跟进提交 + push
+
+- `git add -A`
+- Commit: `fix(config): drop project-level .codex/config.toml model pin (#19)`
+- 不创建新 PR，推到同一分支 `fix/issue-19`，PR #20 自动更新

--- a/logs/fix-issue-19/tasks.md
+++ b/logs/fix-issue-19/tasks.md
@@ -1,0 +1,36 @@
+# Tasks — fix-issue-19
+
+## T1: RED — 验证当前状态命中 3 处硬编码
+
+- Run: `grep -rn -- '--model gpt-5\.4' plugins/ai-driver/commands/`
+- Expected: 3 hits (review-pr.md:255, run-spec.md:159, run-spec.md:354)
+- Maps to: AC1 (initial RED state)
+
+## T2: GREEN — 删除 plugins/ai-driver/commands/run-spec.md:159 的 `--model gpt-5.4 `
+
+- Edit: 仅删除 `--model gpt-5.4 ` 这串（含尾部空格），其余保留
+- Maps to: AC1, AC2, AC3 partial
+
+## T3: GREEN — 删除 plugins/ai-driver/commands/run-spec.md:354 的 `--model gpt-5.4 `
+
+- Edit: 同上模式
+- Maps to: AC1, AC2, AC3 partial
+
+## T4: GREEN — 删除 plugins/ai-driver/commands/review-pr.md:255 的 `--model gpt-5.4 `
+
+- Edit: 同上模式
+- Maps to: AC1, AC2, AC3 partial
+
+## T5: 验收 — 运行 AC1..AC4
+
+- AC1: `! grep -rn -- '--model gpt-5\.4' plugins/ai-driver/commands/`
+- AC2: `codex exec` 出现 3 次
+- AC3: `model_reasoning_effort` 保留 3 次
+- AC4: `gpt-5.4` 字面量在 commands/ 下不再出现
+- Maps to: 全部 AC
+
+## T6: 提交 + PR
+
+- `git add specs/fix-issue-19.spec.md plugins/ai-driver/commands/run-spec.md plugins/ai-driver/commands/review-pr.md logs/fix-issue-19/`
+- Commit: `fix(commands): drop hardcoded --model gpt-5.4 from codex calls (#19)`
+- Push + `gh pr create`

--- a/plugins/ai-driver/commands/review-pr.md
+++ b/plugins/ai-driver/commands/review-pr.md
@@ -252,7 +252,7 @@ Dispatch Codex via Claude Code's `Bash(run_in_background=true)` pattern — NOT 
 ```bash
 # The main agent invokes this via the Bash tool with run_in_background=true.
 # Shell form shown for audit.
-codex exec --model gpt-5.4 --config model_reasoning_effort="high" -s read-only "$PASS2_PROMPT" < "$STAGE/diff.txt"
+codex exec --config model_reasoning_effort="high" -s read-only "$PASS2_PROMPT" < "$STAGE/diff.txt"
 ```
 
 `$PASS2_PROMPT` is the literal prompt block below. Codex reads the diff on stdin; for the reviewer / comment artifacts, the prompt names the `$STAGE/*.json` paths and Codex reads them via its own sandbox (it also has filesystem read under `-s read-only`).

--- a/plugins/ai-driver/commands/run-spec.md
+++ b/plugins/ai-driver/commands/run-spec.md
@@ -156,7 +156,7 @@ Run Codex as a tracked background job so the notification arrives automatically 
 # for audit clarity):
 # Wrap stdin in the BEGIN/END SPEC fences the Layer 2 literal prompt expects:
 { printf -- '---BEGIN SPEC---\n'; cat "$SPEC_PATH"; printf -- '\n---END SPEC---\n'; } | \
-  codex exec --model gpt-5.4 --config model_reasoning_effort="high" -s read-only "$CODEX_SPEC_REVIEW_PROMPT"
+  codex exec --config model_reasoning_effort="high" -s read-only "$CODEX_SPEC_REVIEW_PROMPT"
 ```
 
 Notes:
@@ -351,7 +351,7 @@ Exactly those three, nothing else. Main session passes `plan.md` as a **path arg
 - Invocation (shell form shown for audit; main agent uses the Bash tool with `run_in_background=true`):
 
   ```bash
-  codex exec --model gpt-5.4 --config model_reasoning_effort="high" -s read-only \
+  codex exec --config model_reasoning_effort="high" -s read-only \
     "$PLAN_REVIEW_PROMPT" < logs/<spec-slug>/plan.md
   ```
 - `$PLAN_REVIEW_PROMPT` is the literal prompt block above. Codex receives the same Focus (plan review): + Out of scope (plan review): + plan-anchor whitelist as the subagent pass — the dual-LLM arrangement means the scope fence applies symmetrically, and cross-pass consensus operates only on the surviving main findings.

--- a/plugins/ai-driver/templates/.codex/config.toml
+++ b/plugins/ai-driver/templates/.codex/config.toml
@@ -1,5 +1,0 @@
-# Codex project-level configuration
-# See: https://developers.openai.com/codex/config-advanced
-
-model = "gpt-5.4"
-model_reasoning_effort = "high"

--- a/plugins/ai-driver/templates/.github/workflows/template-sync.yml
+++ b/plugins/ai-driver/templates/.github/workflows/template-sync.yml
@@ -19,7 +19,6 @@ jobs:
             ".github/workflows/auto-release.yml:plugins/ai-driver/templates/.github/workflows/auto-release.yml"
             ".github/workflows/ci.yml:plugins/ai-driver/templates/.github/workflows/ci.yml"
             ".github/workflows/template-sync.yml:plugins/ai-driver/templates/.github/workflows/template-sync.yml"
-            ".codex/config.toml:plugins/ai-driver/templates/.codex/config.toml"
             "constitution.md:plugins/ai-driver/templates/constitution.md"
             "CLAUDE.md:plugins/ai-driver/templates/CLAUDE.md"
             "specs/_template.spec.md:plugins/ai-driver/templates/specs/_template.spec.md"

--- a/specs/fix-issue-19.spec.md
+++ b/specs/fix-issue-19.spec.md
@@ -1,0 +1,62 @@
+---
+Goal: 移除 codex 调用中硬编码的 `--model gpt-5.4`，让 codex CLI 自身的默认模型生效，使框架能随 codex 升级自动跟进最新模型，无需修改本仓库。
+Review Level: A
+Source: GitHub issue #19 (https://github.com/HuMoran/AI-driver/issues/19)
+---
+
+## Goal
+
+移除 `plugins/ai-driver/commands/` 下三处 `codex exec --model gpt-5.4` 中的 `--model gpt-5.4` 硬编码，使 Codex 子进程沿用 codex CLI 自身默认模型（由 `~/.codex/config.toml` 或 codex 内置默认决定）。
+
+## Context
+
+> Comment from @HuMoran (issue body) @ 2026-04-29 (human author, is_bot=false):
+> commands里面，用codex做对抗性审查时，把模型写死的 gpt-5.4，
+> 这会导致当gpt升级后，默认没有调用最新模型
+
+**根因分析 (R-004)**：
+
+三处 `codex exec --model gpt-5.4` 硬编码：
+
+| 文件 | 行号 | 用途 |
+|------|------|------|
+| `plugins/ai-driver/commands/run-spec.md` | 159 | Phase 0 Layer 2 spec review |
+| `plugins/ai-driver/commands/run-spec.md` | 354 | Plan review Pass 2 |
+| `plugins/ai-driver/commands/review-pr.md` | 255 | Pass 2 adversarial diff review |
+
+`codex exec --help` 验证：`-m, --model <MODEL>` 不传时，由 `~/.codex/config.toml` 决定，等同于"跟随 codex CLI 自身的默认值"。因此移除该 flag 即可让升级自动生效。
+
+**模板镜像影响**：`.github/workflows/template-sync.yml` 的 PAIRS 列表不含 `plugins/ai-driver/commands/*`（只覆盖 `.github/`、`.codex/`、constitution.md、CLAUDE.md、specs/_template.*）。无需同步到 templates。
+
+**正交 skill**：`codex:gpt-5-4-prompting` 是 Claude 侧的 prompting 指南，与 codex 子进程的模型选择正交，不受本变更影响。
+
+## User Scenarios
+
+GIVEN 用户已升级 codex CLI（其默认模型从 gpt-5.4 升到下一代）
+WHEN  在本仓库运行 `/ai-driver:run-spec` 或 `/ai-driver:review-pr`
+THEN  Codex 子进程必须使用 codex CLI 当前默认模型，而非 `gpt-5.4`
+
+GIVEN 用户希望临时锁定到某个模型
+WHEN  在 `~/.codex/config.toml` 设置 `model = "..."` 或调用方注入 `-c model="..."`
+THEN  本仓库不再硬编码覆盖，用户层面配置生效
+
+## Acceptance Criteria
+
+AC1: `! grep -rn -- '--model gpt-5\.4' plugins/ai-driver/commands/`
+     —— 三处硬编码已全部移除（grep 退出码非 0 即通过）
+
+AC2: `[ "$(grep -c 'codex exec' plugins/ai-driver/commands/review-pr.md plugins/ai-driver/commands/run-spec.md | awk -F: '{s+=$2} END {print s}')" = "4" ]`
+     —— `codex exec` 文本出现次数仍为 4（3 处沙盒调用 + run-spec.md:380 prose 示例；仅去掉 `--model` flag，不增删行）
+
+AC3: `grep -n 'model_reasoning_effort=\"high\"' plugins/ai-driver/commands/review-pr.md plugins/ai-driver/commands/run-spec.md | wc -l | tr -d ' '` 输出 `3`
+     —— 周边 `--config model_reasoning_effort="high"` 全部保留（P5 最小变更）
+
+AC4: `! grep -rn 'gpt-5\.4' plugins/ai-driver/commands/`
+     —— commands/ 下不再出现 `gpt-5.4` 字面量（兜底校验）
+
+## Constraints (from constitution.md)
+
+- **P5 最小变更**：仅删除 `--model gpt-5.4` token，不调整周边参数（`--config model_reasoning_effort="high"`、`-s read-only` 等保留）
+- **R-005 原子提交**：单一 `fix(commands): ...` 提交完成全部三处
+- **R-006 提交前格式化**：Markdown 保持现有缩进/换行，不重排
+- **R-003 不扩展范围**：不顺手清理其他无关文档

--- a/specs/fix-issue-19.spec.md
+++ b/specs/fix-issue-19.spec.md
@@ -6,7 +6,10 @@ Source: GitHub issue #19 (https://github.com/HuMoran/AI-driver/issues/19)
 
 ## Goal
 
-移除 `plugins/ai-driver/commands/` 下三处 `codex exec --model gpt-5.4` 中的 `--model gpt-5.4` 硬编码，使 Codex 子进程沿用 codex CLI 自身默认模型（由 `~/.codex/config.toml` 或 codex 内置默认决定）。
+让 codex CLI 自身的默认模型生效，使框架能随 codex 升级自动跟进最新模型，无需修改本仓库。具体修改两类位置：
+
+1. `plugins/ai-driver/commands/` 下三处 `codex exec --model gpt-5.4`：移除 `--model gpt-5.4` flag
+2. `.codex/config.toml`（repo 根 + 模板镜像）：整文件删除（同时从 `template-sync.yml` PAIRS 中摘除该 pair）
 
 ## Context
 
@@ -14,19 +17,26 @@ Source: GitHub issue #19 (https://github.com/HuMoran/AI-driver/issues/19)
 > commands里面，用codex做对抗性审查时，把模型写死的 gpt-5.4，
 > 这会导致当gpt升级后，默认没有调用最新模型
 
-**根因分析 (R-004)**：
+**根因分析 (R-004)**：模型版本被 pin 在两个层级：
 
-三处 `codex exec --model gpt-5.4` 硬编码：
-
-| 文件 | 行号 | 用途 |
+| 位置 | 内容 | 影响 |
 |------|------|------|
-| `plugins/ai-driver/commands/run-spec.md` | 159 | Phase 0 Layer 2 spec review |
-| `plugins/ai-driver/commands/run-spec.md` | 354 | Plan review Pass 2 |
-| `plugins/ai-driver/commands/review-pr.md` | 255 | Pass 2 adversarial diff review |
+| `plugins/ai-driver/commands/run-spec.md:159` | `--model gpt-5.4` | Phase 0 Layer 2 spec review |
+| `plugins/ai-driver/commands/run-spec.md:354` | `--model gpt-5.4` | Plan review Pass 2 |
+| `plugins/ai-driver/commands/review-pr.md:255` | `--model gpt-5.4` | Pass 2 adversarial diff review |
+| `.codex/config.toml:4` | `model = "gpt-5.4"` | 项目级 config，对从 template 初始化的新用户可能仍然 pin 模型 |
+| `plugins/ai-driver/templates/.codex/config.toml:4` | `model = "gpt-5.4"` | 上面的镜像（被 `template-sync.yml` PAIRS 强制 byte-identical） |
 
-`codex exec --help` 验证：`-m, --model <MODEL>` 不传时，由 `~/.codex/config.toml` 决定，等同于"跟随 codex CLI 自身的默认值"。因此移除该 flag 即可让升级自动生效。
+**仅删 commands flag 不够**：codex CLI 的配置解析链中，项目级 `.codex/config.toml` 可能在用户级 `~/.codex/config.toml` 之前/之后被读取（codex 文档不明确，且 `codex exec --help` 仅提到用户级）。即便本机实证（maintainer 的 `~/.codex/config.toml` pin 了 gpt-5.5，banner 显示 `model: gpt-5.5`）说明用户级生效，**对于从模板初始化的新用户（无 `~/.codex/config.toml` 或其中无 `model =` 行），项目级配置仍可能把他们 pin 在 gpt-5.4** —— 完全违背 issue 原意。
 
-**模板镜像影响**：`.github/workflows/template-sync.yml` 的 PAIRS 列表不含 `plugins/ai-driver/commands/*`（只覆盖 `.github/`、`.codex/`、constitution.md、CLAUDE.md、specs/_template.*）。无需同步到 templates。
+**为何整文件删除而非仅删 `model` 行**：
+
+- `model` 是问题
+- `model_reasoning_effort = "high"` 在三处 `codex exec` 调用中已通过 `-c model_reasoning_effort="high"` 显式传入，项目级 config 中冗余
+- 文件中没有其他 key
+- 删除整文件比"删一行保留一行"更干净，行为不变
+
+**模板同步影响**：删除两侧 `.codex/config.toml` 后，`.github/workflows/template-sync.yml` 的 PAIRS 列表中 `.codex/config.toml:plugins/ai-driver/templates/.codex/config.toml` 这一行也必须摘除，否则 CI 会报"file missing"。同时 `plugins/ai-driver/templates/.github/workflows/template-sync.yml` 是该文件的镜像，也要同步修改。
 
 **正交 skill**：`codex:gpt-5-4-prompting` 是 Claude 侧的 prompting 指南，与 codex 子进程的模型选择正交，不受本变更影响。
 
@@ -36,6 +46,10 @@ GIVEN 用户已升级 codex CLI（其默认模型从 gpt-5.4 升到下一代）
 WHEN  在本仓库运行 `/ai-driver:run-spec` 或 `/ai-driver:review-pr`
 THEN  Codex 子进程必须使用 codex CLI 当前默认模型，而非 `gpt-5.4`
 
+GIVEN 一个新用户从模板初始化项目，且 `~/.codex/config.toml` 不存在或不包含 `model =` 行
+WHEN  其在新项目中运行 `/ai-driver:run-spec`
+THEN  Codex 子进程不应被项目级 `.codex/config.toml` pin 到 `gpt-5.4`，应使用 codex CLI 内置默认
+
 GIVEN 用户希望临时锁定到某个模型
 WHEN  在 `~/.codex/config.toml` 设置 `model = "..."` 或调用方注入 `-c model="..."`
 THEN  本仓库不再硬编码覆盖，用户层面配置生效
@@ -43,20 +57,29 @@ THEN  本仓库不再硬编码覆盖，用户层面配置生效
 ## Acceptance Criteria
 
 AC1: `! grep -rn -- '--model gpt-5\.4' plugins/ai-driver/commands/`
-     —— 三处硬编码已全部移除（grep 退出码非 0 即通过）
+     —— 三处 commands 硬编码已全部移除
 
 AC2: `[ "$(grep -c 'codex exec' plugins/ai-driver/commands/review-pr.md plugins/ai-driver/commands/run-spec.md | awk -F: '{s+=$2} END {print s}')" = "4" ]`
-     —— `codex exec` 文本出现次数仍为 4（3 处沙盒调用 + run-spec.md:380 prose 示例；仅去掉 `--model` flag，不增删行）
+     —— `codex exec` 文本出现次数仍为 4（3 处沙盒调用 + run-spec.md:380 prose 示例）
 
 AC3: `grep -n 'model_reasoning_effort=\"high\"' plugins/ai-driver/commands/review-pr.md plugins/ai-driver/commands/run-spec.md | wc -l | tr -d ' '` 输出 `3`
-     —— 周边 `--config model_reasoning_effort="high"` 全部保留（P5 最小变更）
+     —— 周边 `--config model_reasoning_effort="high"` 全部保留
 
 AC4: `! grep -rn 'gpt-5\.4' plugins/ai-driver/commands/`
-     —— commands/ 下不再出现 `gpt-5.4` 字面量（兜底校验）
+     —— commands/ 下不再出现 `gpt-5.4` 字面量
+
+AC5: `[ ! -e .codex/config.toml ] && [ ! -e plugins/ai-driver/templates/.codex/config.toml ]`
+     —— 两侧 `.codex/config.toml` 已删除（项目级 model pin 不再存在）
+
+AC6: `! grep -n '\.codex/config\.toml' .github/workflows/template-sync.yml plugins/ai-driver/templates/.github/workflows/template-sync.yml`
+     —— PAIRS 中 `.codex` 条目已摘除（避免 template-sync CI 抱怨 missing）
+
+AC7: `diff -q .github/workflows/template-sync.yml plugins/ai-driver/templates/.github/workflows/template-sync.yml`
+     —— template-sync.yml 自身的两侧仍 byte-identical（PAIRS 改动两侧同步）
 
 ## Constraints (from constitution.md)
 
-- **P5 最小变更**：仅删除 `--model gpt-5.4` token，不调整周边参数（`--config model_reasoning_effort="high"`、`-s read-only` 等保留）
-- **R-005 原子提交**：单一 `fix(commands): ...` 提交完成全部三处
-- **R-006 提交前格式化**：Markdown 保持现有缩进/换行，不重排
-- **R-003 不扩展范围**：不顺手清理其他无关文档
+- **P5 最小变更**：commands 三处仅删 `--model gpt-5.4` flag；`.codex/config.toml` 整文件删除（保留 `model_reasoning_effort` 没有意义，已通过 `-c` flag 传递）
+- **R-005 原子提交**：本次扩展为单一 `fix(commands+config): ...` 跟进 PR review；首次提交保留原样作为审查痕迹
+- **R-006 提交前格式化**：Markdown / YAML 保持现有缩进/换行
+- **R-003 范围管理**：扩展受 PR review consensus 驱动（Pass 1 + Codex Pass 2 + Copilot 三源），不算"顺手清理"


### PR DESCRIPTION
Fixes #19

## Summary

- 移除 `plugins/ai-driver/commands/run-spec.md` (Phase 0 Layer 2 spec review、Plan review Pass 2) 与 `plugins/ai-driver/commands/review-pr.md` (Pass 2 adversarial diff review) 三处 `codex exec --model gpt-5.4` 中的 `--model gpt-5.4`。
- 不传 `--model` 时 codex 由 `~/.codex/config.toml` 或自身默认值决定模型，框架因此可随 codex CLI 升级自动跟进新模型，无需逐版本修订。
- P5 最小变更：周边 `--config model_reasoning_effort="high"` 与 `-s read-only` 全部保留。

## Acceptance evidence

| AC | 命令 | 结果 |
|----|------|------|
| AC1 | `! grep -rn -- '--model gpt-5\.4' plugins/ai-driver/commands/` | PASS（0 hits） |
| AC2 | `codex exec` 文本仍出现 4 次（3 沙盒调用 + 1 prose 示例） | PASS（count=4） |
| AC3 | `model_reasoning_effort="high"` 仍出现 3 次 | PASS（count=3） |
| AC4 | `! grep -rn 'gpt-5\.4' plugins/ai-driver/commands/` | PASS（0 hits） |

Spec：`specs/fix-issue-19.spec.md`。Plan / tasks：`logs/fix-issue-19/`。

## Migration / compatibility

- 用户层若希望锁定特定模型：在 `~/.codex/config.toml` 添加 `model = "..."`，或在调用方注入 `-c model="..."`。
- `codex:gpt-5-4-prompting` skill 是 Claude 侧 prompting 指南，与 codex 子进程模型选择正交，未受影响。
- `template-sync.yml` PAIRS 不含 `plugins/ai-driver/commands/*`，无需镜像同步。

## Test plan

- [x] AC1–AC4 本地通过（见上表）
- [ ] CI: template-sync (commands/* 不在 PAIRS，预期通过)
- [ ] CI: 其他工作流