### PR TITLE
feat(commands): print codex config before each pass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Language-agnostic AI-driven development framework. Humans write specs, AI does the rest.",
-    "version": "0.4.6"
+    "version": "0.5.0"
   },
   "plugins": [
     {
       "name": "ai-driver",
       "source": "./plugins/ai-driver",
       "description": "Claude Code plugin for the AI-driver framework",
-      "version": "0.4.6",
+      "version": "0.5.0",
       "author": {
         "name": "HuMoran"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Print codex configuration before each pass.** Each `codex exec` call site in `plugins/ai-driver/commands/run-spec.md` (Phase 0 Layer 2 spec review, Plan review Pass 2) and `plugins/ai-driver/commands/review-pr.md` (Pass 2 adversarial diff review) now precedes the codex invocation with two bash lines that resolve `~/.codex/config.toml`'s `model =` (or `<codex-cli-default>` if absent) and echo a one-line summary to stderr: `[ai-driver] Codex pass: model=<resolved> reasoning_effort=high cwd=<...>`. Without this, downstream of issue #19 (which removed the `--model gpt-5.4` pin), users had no direct visibility into which model their codex CLI defaulted to — a quiet drift to a low-cost model would silently degrade dual-blind review quality. Non-blocking (no interactive prompt; preserves P6 automated pipeline). The optional `AI_DRIVER_REQUIRE_CONFIRM=1` blocking-confirm flag mentioned in issue #21 is intentionally out of scope: `Bash(run_in_background=true)` cannot interactively `read`, and adding confirmation requires redesigning the codex dispatch flow. Fixes #21.
+
 ## [0.4.6] - 2026-04-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-29
+
 ### Added
 
 - **Print codex configuration before each pass.** Each `codex exec` call site in `plugins/ai-driver/commands/run-spec.md` (Phase 0 Layer 2 spec review, Plan review Pass 2) and `plugins/ai-driver/commands/review-pr.md` (Pass 2 adversarial diff review) now precedes the codex invocation with two bash lines that resolve `~/.codex/config.toml`'s `model =` (or `<codex-cli-default>` if absent) and echo a one-line summary to stderr: `[ai-driver] Codex pass: model=<resolved> reasoning_effort=high cwd=<...>`. Without this, downstream of issue #19 (which removed the `--model gpt-5.4` pin), users had no direct visibility into which model their codex CLI defaulted to — a quiet drift to a low-cost model would silently degrade dual-blind review quality. Non-blocking (no interactive prompt; preserves P6 automated pipeline). The optional `AI_DRIVER_REQUIRE_CONFIRM=1` blocking-confirm flag mentioned in issue #21 is intentionally out of scope: `Bash(run_in_background=true)` cannot interactively `read`, and adding confirmation requires redesigning the codex dispatch flow. Fixes #21.

--- a/logs/fix-issue-21/plan.md
+++ b/logs/fix-issue-21/plan.md
@@ -1,0 +1,37 @@
+# Plan — fix-issue-21
+
+## Architecture
+
+无架构变更。三处 markdown 中的 bash 代码块顶部各插入 2 行：
+
+```bash
+RESOLVED_MODEL=$(awk -F'[ "=]+' '/^model[[:space:]]*=/{print $2; exit}' ~/.codex/config.toml 2>/dev/null || echo '<codex-cli-default>')
+echo "[ai-driver] Codex pass: model=$RESOLVED_MODEL reasoning_effort=high cwd=$(pwd)" >&2
+```
+
+`>&2` 导到 stderr，避免污染 codex 的 stdout 流（在 `Bash(run_in_background=true)` 模式下，stdout 被 `> "$out"` 捕获，stderr 被 `2> "$out.err"` 捕获 —— 但 echo 出现在 codex 启动**之前**，且主 agent 通过 BashOutput 读取整个流；用户在主会话 tool output 中看得见）。
+
+## Reuse analysis
+
+- 复用现有 awk + sed/grep 工具链（无新依赖）
+- 复用 markdown bash 块结构（不改 fence、不改语言标记）
+
+## Risk analysis
+
+| 风险 | 影响 | 缓解 |
+|------|------|------|
+| `awk` 解析 TOML 太粗（`model = "gpt-5.5"` 的引号、空格、注释行） | 偶尔解析出错误值 | awk 模式 `^model[[:space:]]*=` + 字段分隔 `[ "=]+` 已处理常见情况；最坏情况输出"古怪 token"，用户仍可识别异常 |
+| 用户没有 `~/.codex/config.toml` | awk 在不存在文件上失败 | `2>/dev/null \|\| echo '<codex-cli-default>'` 兜底 |
+| echo 写到 stderr 后被 `2> "$out.err"` 吞掉 | 主会话仍看不见 | 主 agent Bash 工具回传整个 stderr；BashOutput 读取时一并显示。如果未来某个 wrapper 强吞 stderr，再切换到 stdout |
+| markdown bash 块被工具误认为可执行 shell 脚本 | 误执行风险 | 这 3 个块本来就标注了 "shell form shown for audit; main agent uses the Bash tool"，无变化 |
+
+## Test strategy
+
+- AC1/AC5/AC6：grep 字面量计数
+- AC2：`awk` 上下文校验（echo 在对应 codex exec 5 行内）
+- AC3：防 #19 回归
+- AC4：codex exec 调用次数不变
+
+## TDD note
+
+变更为 markdown 文档式 bash，TDD 映射为：先写 grep AC（spec 中已固化）→ 当前 grep 命中 0 次（RED）→ 加 echo 行 → grep 命中 3 次（GREEN）→ 无 REFACTOR。

--- a/logs/fix-issue-21/tasks.md
+++ b/logs/fix-issue-21/tasks.md
@@ -1,0 +1,33 @@
+# Tasks — fix-issue-21
+
+## T1: RED — 验证当前状态命中 0 处 echo
+
+- Run: `grep -c '\[ai-driver\] Codex pass:' plugins/ai-driver/commands/run-spec.md plugins/ai-driver/commands/review-pr.md`
+- Expected: 0:0 三处文件均 0
+- Maps to: AC1 (initial RED)
+
+## T2: GREEN — 在 plugins/ai-driver/commands/run-spec.md:159 之前插入 RESOLVED_MODEL + echo
+
+- Edit: 在 `codex exec --config model_reasoning_effort="high" -s read-only "$CODEX_SPEC_REVIEW_PROMPT"` 行之前的 bash 行（pipe 之后）插入 2 行
+- Maps to: AC1, AC5, AC6
+
+## T3: GREEN — 在 plugins/ai-driver/commands/run-spec.md:354 之前插入
+
+- Edit: 在 Plan review Pass 2 的 codex exec 之前
+- Maps to: AC1, AC5, AC6
+
+## T4: GREEN — 在 plugins/ai-driver/commands/review-pr.md:255 之前插入
+
+- Edit: 在 Pass 2 adversarial review 的 codex exec 之前
+- Maps to: AC1, AC5, AC6
+
+## T5: 验收 — 运行 AC1..AC6
+
+- 全部必须 PASS
+- 特别注意 AC2 的上下文校验（echo 在对应 codex exec 5 行内）
+
+## T6: 提交 + PR
+
+- `git add specs/fix-issue-21.spec.md plugins/ai-driver/commands/{run-spec.md,review-pr.md} logs/fix-issue-21/ CHANGELOG.md`
+- Commit: `feat(commands): print codex config before each pass (#21)`
+- Push + `gh pr create`

--- a/plugins/ai-driver/commands/review-pr.md
+++ b/plugins/ai-driver/commands/review-pr.md
@@ -252,6 +252,8 @@ Dispatch Codex via Claude Code's `Bash(run_in_background=true)` pattern — NOT 
 ```bash
 # The main agent invokes this via the Bash tool with run_in_background=true.
 # Shell form shown for audit.
+RESOLVED_MODEL=$(awk -F'[ "=]+' '/^model[[:space:]]*=/{print $2; exit}' ~/.codex/config.toml 2>/dev/null || echo '<codex-cli-default>')
+echo "[ai-driver] Codex pass: model=$RESOLVED_MODEL reasoning_effort=high cwd=$(pwd)" >&2
 codex exec --config model_reasoning_effort="high" -s read-only "$PASS2_PROMPT" < "$STAGE/diff.txt"
 ```
 

--- a/plugins/ai-driver/commands/run-spec.md
+++ b/plugins/ai-driver/commands/run-spec.md
@@ -155,6 +155,8 @@ Run Codex as a tracked background job so the notification arrives automatically 
 # tool, not a literal shell snippet; shown here as the equivalent shell form
 # for audit clarity):
 # Wrap stdin in the BEGIN/END SPEC fences the Layer 2 literal prompt expects:
+RESOLVED_MODEL=$(awk -F'[ "=]+' '/^model[[:space:]]*=/{print $2; exit}' ~/.codex/config.toml 2>/dev/null || echo '<codex-cli-default>')
+echo "[ai-driver] Codex pass: model=$RESOLVED_MODEL reasoning_effort=high cwd=$(pwd)" >&2
 { printf -- '---BEGIN SPEC---\n'; cat "$SPEC_PATH"; printf -- '\n---END SPEC---\n'; } | \
   codex exec --config model_reasoning_effort="high" -s read-only "$CODEX_SPEC_REVIEW_PROMPT"
 ```
@@ -351,6 +353,8 @@ Exactly those three, nothing else. Main session passes `plan.md` as a **path arg
 - Invocation (shell form shown for audit; main agent uses the Bash tool with `run_in_background=true`):
 
   ```bash
+  RESOLVED_MODEL=$(awk -F'[ "=]+' '/^model[[:space:]]*=/{print $2; exit}' ~/.codex/config.toml 2>/dev/null || echo '<codex-cli-default>')
+  echo "[ai-driver] Codex pass: model=$RESOLVED_MODEL reasoning_effort=high cwd=$(pwd)" >&2
   codex exec --config model_reasoning_effort="high" -s read-only \
     "$PLAN_REVIEW_PROMPT" < logs/<spec-slug>/plan.md
   ```

--- a/specs/fix-issue-21.spec.md
+++ b/specs/fix-issue-21.spec.md
@@ -1,0 +1,92 @@
+---
+Goal: 在每次 codex 子进程启动前，主流程显式向 stderr 输出一行可见的配置摘要，让用户在 dual-blind 审查 / plan review / spec review 过程中立刻识别实际生效的模型，避免用户级 `~/.codex/config.toml` 漂移导致 dual-blind 审查质量静默下降。
+Review Level: A
+Source: GitHub issue #21 (https://github.com/HuMoran/AI-driver/issues/21)
+---
+
+## Goal
+
+在三处 `codex exec` 调用之前各加 2 行 bash：
+
+```bash
+RESOLVED_MODEL=$(awk -F'[ "=]+' '/^model[[:space:]]*=/{print $2; exit}' ~/.codex/config.toml 2>/dev/null || echo '<codex-cli-default>')
+echo "[ai-driver] Codex pass: model=$RESOLVED_MODEL reasoning_effort=high cwd=$(pwd)" >&2
+```
+
+输出写到 stderr，避免污染 codex 的 stdout 收集流。
+
+## Context
+
+> Issue #21 from @HuMoran @ 2026-04-29 (human, is_bot=false):
+> #19 已移除 `codex exec --model gpt-5.4` 硬编码，让 codex CLI 自身的默认模型生效。
+> 但用户对"实际运行时用了什么模型 / reasoning_effort"失去了直接可见性 ——
+> 如果用户的 `~/.codex/config.toml` 默认漂到一个低成本/低能力模型，
+> dual-blind 审查质量会静默下降。
+
+**根因 (R-004)**：
+
+- codex CLI 自身的 banner（`model: ...` / `reasoning effort: ...` / `workdir: ...`）写到 stderr。
+- 三处调用都通过 `Bash(run_in_background=true)` + `2> "$out.err"` 把 stderr 重定向到 staging tempdir。
+- 主会话的 tool output 看不到 banner，所以模型可见性丢了。
+- 解决方案：在 codex 启动前，主会话自己 echo 一行到 stderr —— 因为 `Bash(run_in_background=true)` 的 wrapper 是 ai-driver 自己写的 bash 块，echo 输出会进入 background task 的 stdout/stderr 通道，主 agent 的 BashOutput 读取该流时即可看到。但更直接的做法是，在主会话 dispatch 之前，于"foreground 准备阶段"echo（即 markdown 中提供的"shell form 用于审计"snippet 移到主 agent 真正执行的部分），见 §scope。
+
+**实际实现策略**（重要）：
+
+回看现有 markdown，三处 codex 调用所在的 ` ```bash ` 块都标注了 `# Shell form shown for audit; main agent uses the Bash tool with run_in_background=true`。即 markdown 内的 bash 块本身是"主 agent 应执行的内容"的伪代码 / 审计形式。本变更采取的做法是：
+
+1. 在每个 bash 块顶部加 `RESOLVED_MODEL=...; echo ... >&2` 两行
+2. 主 agent 在调用 Bash 工具时，会把整个块作为单条命令传入；echo 在 codex exec **之前**先执行，结果对主会话 stdout 直接可见（`>&2` 落到 stderr，但 Bash 工具的 task notification 同时回传 stdout/stderr）
+
+**三处 call site**：
+
+- `plugins/ai-driver/commands/run-spec.md:159` (Phase 0 Layer 2 spec review)
+- `plugins/ai-driver/commands/run-spec.md:354` (Plan review Pass 2)
+- `plugins/ai-driver/commands/review-pr.md:255` (PR review Pass 2)
+
+**模板同步**：`commands/*` 不在 `template-sync.yml` PAIRS 中，无需镜像。
+
+**正交 skill**：与 `codex:gpt-5-4-prompting` 等 Claude 侧 prompting 指南无关。
+
+## User Scenarios
+
+GIVEN 用户的 `~/.codex/config.toml` 含 `model = "gpt-5.5"`
+WHEN  运行 `/ai-driver:run-spec` 或 `/ai-driver:review-pr`
+THEN  在 codex 子进程启动前，主会话的输出流可见一行
+      `[ai-driver] Codex pass: model=gpt-5.5 reasoning_effort=high cwd=/Users/.../project`
+
+GIVEN 用户没有 `~/.codex/config.toml`，或文件中无 `model =` 行
+WHEN  运行 codex 调用
+THEN  显示 `[ai-driver] Codex pass: model=<codex-cli-default> reasoning_effort=high cwd=...`
+
+GIVEN 用户希望 codex 启动前阻塞确认（issue #21 中提到的 `AI_DRIVER_REQUIRE_CONFIRM=1`）
+WHEN  设置该 env 变量
+THEN  **不在本 spec 范围**：`Bash(run_in_background=true)` 的 wrapper 不能交互 `read`，
+      要做需要重新设计 codex 调度流程（main 会话先 echo + 显式询问 → 用户回 y → 再后台 dispatch），
+      属于 P5 不允许的"附带改动"。如需要，开 follow-up issue。
+
+## Acceptance Criteria
+
+AC1: `[ "$(grep -c '\[ai-driver\] Codex pass:' plugins/ai-driver/commands/run-spec.md plugins/ai-driver/commands/review-pr.md | awk -F: '{s+=$2} END {print s}')" = "3" ]`
+     —— 三处 codex 调用对应的 echo 行总数为 3
+
+AC2: 每处 echo 都在对应 codex exec 行之前 5 行内
+     `awk '/\[ai-driver\] Codex pass:/{seen=NR} /codex exec /{ if(seen && NR-seen<=5) hits++; seen=0 } END {exit (hits==3?0:1)}' plugins/ai-driver/commands/run-spec.md plugins/ai-driver/commands/review-pr.md`
+
+AC3: `! grep -rn -- '--model gpt-5\.4' plugins/ai-driver/commands/`
+     —— 不回退 #19 的修复
+
+AC4: `[ "$(grep -c 'codex exec' plugins/ai-driver/commands/review-pr.md plugins/ai-driver/commands/run-spec.md | awk -F: '{s+=$2} END {print s}')" = "4" ]`
+     —— `codex exec` 文本仍 4 次（3 沙盒 + 1 prose 示例），证明只增不删
+
+AC5: 每处新增 echo 都通过 `>&2` 导到 stderr
+     `[ "$(grep -c 'echo "\[ai-driver\] Codex pass:.*>&2$' plugins/ai-driver/commands/run-spec.md plugins/ai-driver/commands/review-pr.md | awk -F: '{s+=$2} END {print s}')" = "3" ]`
+
+AC6: `RESOLVED_MODEL=$(awk` 解析行也对应出现 3 次
+     `[ "$(grep -c '^[[:space:]]*RESOLVED_MODEL=' plugins/ai-driver/commands/run-spec.md plugins/ai-driver/commands/review-pr.md | awk -F: '{s+=$2} END {print s}')" = "3" ]`
+
+## Constraints (from constitution.md)
+
+- **P5 最小变更**：仅在三处 `codex exec` 之前各加 2 行（RESOLVED_MODEL + echo），不动 codex 命令本身、不动 prompt、不动 fence
+- **R-005 原子提交**：单一 `feat(commands): print codex config before each pass (#21)`
+- **R-006 提交前格式化**：保持 markdown 缩进/换行，不重排
+- **R-003 范围管理**：`AI_DRIVER_REQUIRE_CONFIRM` 阻塞模式 out-of-scope；如需要另开 issue


### PR DESCRIPTION
Fixes #21

## Summary

- 在三处 `codex exec` 调用之前各加 2 行 bash：
  ```bash
  RESOLVED_MODEL=$(awk -F'[ "=]+' '/^model[[:space:]]*=/{print $2; exit}' ~/.codex/config.toml 2>/dev/null || echo '<codex-cli-default>')
  echo "[ai-driver] Codex pass: model=$RESOLVED_MODEL reasoning_effort=high cwd=$(pwd)" >&2
  ```
- 解决 #19 之后用户对实际生效模型失去可见性的副作用。
- 非阻塞、`>&2` 写到 stderr，不污染 codex 的 stdout 流。

## Acceptance evidence

| AC | 命令 | 结果 |
|----|------|------|
| AC1 | echo 行总数 = 3 | PASS |
| AC2 | 每处 echo 在对应 `codex exec` 5 行内 | PASS（hits=3） |
| AC3 | 无 `--model gpt-5.4`（防 #19 回归） | PASS |
| AC4 | `codex exec` 文本仍 4 次（3 沙盒 + 1 prose） | PASS |
| AC5 | 每处 echo 都 `>&2` | PASS |
| AC6 | `RESOLVED_MODEL=` 行 = 3 | PASS |

`tests/review-synthesis/drift-demotion.sh` 仍 4 fixtures all pass。

Spec: `specs/fix-issue-21.spec.md`. Plan/tasks: `logs/fix-issue-21/`.

## Out of scope

- `AI_DRIVER_REQUIRE_CONFIRM=1` 阻塞确认（issue #21 提到的 stretch）—— `Bash(run_in_background=true)` 不能交互 `read`，需要重新设计 codex 调度流程，超过 P5 最小变更。如果需要，再开 follow-up issue。

## Test plan

- [x] AC1–AC6 本地通过
- [x] regression（drift-demotion）通过
- [ ] CI: template-sync (commands/* 不在 PAIRS, 预期通过)
- [ ] CI: 其他工作流